### PR TITLE
Pass-through `sqsEnabled` variable

### DIFF
--- a/environments/demo/values/hocs-search.yaml.gotmpl
+++ b/environments/demo/values/hocs-search.yaml.gotmpl
@@ -1,1 +1,6 @@
 ---
+hocs-generic-service:
+
+  app:
+    env:
+      sqsEnabled: 'false'

--- a/environments/preprod/values/hocs-search.yaml.gotmpl
+++ b/environments/preprod/values/hocs-search.yaml.gotmpl
@@ -1,1 +1,6 @@
 ---
+hocs-generic-service:
+
+  app:
+    env:
+      sqsEnabled: 'false'

--- a/environments/prod/values/hocs-search.yaml.gotmpl
+++ b/environments/prod/values/hocs-search.yaml.gotmpl
@@ -1,1 +1,6 @@
 ---
+hocs-generic-service:
+
+  app:
+    env:
+      sqsEnabled: 'false'

--- a/environments/qa/values/hocs-search.yaml.gotmpl
+++ b/environments/qa/values/hocs-search.yaml.gotmpl
@@ -1,1 +1,6 @@
 ---
+hocs-generic-service:
+
+  app:
+    env:
+      sqsEnabled: 'false'

--- a/environments/qax/values/hocs-search.yaml.gotmpl
+++ b/environments/qax/values/hocs-search.yaml.gotmpl
@@ -1,1 +1,6 @@
 ---
+hocs-generic-service:
+
+  app:
+    env:
+      sqsEnabled: 'false'


### PR DESCRIPTION
Pass-through the `sqsEnabled` environment property for each environment that allows for eventual deprecation of the variable in favour of a profile.