### PR TITLE
Enable hocs-notify in prod.

### DIFF
--- a/environments/prod/charts.yaml.gotmpl
+++ b/environments/prod/charts.yaml.gotmpl
@@ -32,9 +32,6 @@ charts:
   hocs_network_policies:
     deploy: false
 
-  hocs-notify:
-    deploy: false
-
   hocs-outbound-proxy:
     deploy: false
 

--- a/environments/prod/versions.yaml
+++ b/environments/prod/versions.yaml
@@ -10,7 +10,7 @@ versions:
   hocs_info_service:
   hocs_management_ui:
   hocs_network_policies:
-  hocs_notify:
+  hocs_notify: 1.4.1
   hocs_outbound_proxy:
   hocs_queue_tool:
   hocs_search:


### PR DESCRIPTION
This will deploy the current version of notify that is in prod, but bringing it under helm control.