### PR TITLE
Enable hocs-outbound-proxy in prod.

### DIFF
--- a/environments/prod/charts.yaml.gotmpl
+++ b/environments/prod/charts.yaml.gotmpl
@@ -32,9 +32,6 @@ charts:
   hocs_network_policies:
     deploy: false
 
-  hocs-outbound-proxy:
-    deploy: false
-
   hocs-queue-tool:
     deploy: false
 

--- a/environments/prod/versions.yaml
+++ b/environments/prod/versions.yaml
@@ -11,7 +11,7 @@ versions:
   hocs_management_ui:
   hocs_network_policies:
   hocs_notify: 1.4.1
-  hocs_outbound_proxy:
+  hocs_outbound_proxy: 1.0.1
   hocs_queue_tool:
   hocs_search:
   hocs_search_consumer:


### PR DESCRIPTION
This will deploy the current version that is in prod, but bringing it under helm control.