### PR TITLE
HOCS-6004: enable DCU mat-view cronjob

### DIFF
--- a/base/values/prod/hocs-extracts.yaml.gotmpl
+++ b/base/values/prod/hocs-extracts.yaml.gotmpl
@@ -29,3 +29,8 @@ hocs-generic-service:
         memory: 1536Mi
       requests:
         memory: 1536Mi
+
+{{- if hasPrefix "cs-" .Environment.Name }}
+dcuCaseView:
+  enabled: true
+{{- end }}


### PR DESCRIPTION
Enable the DCU materialised view cronjob in production CS environments.