### PR TITLE
HOCS-6000: Correct keycloak domain

### DIFF
--- a/base/values/prod/hocs-management-ui.yaml.gotmpl
+++ b/base/values/prod/hocs-management-ui.yaml.gotmpl
@@ -18,13 +18,13 @@ hocs-generic-service:
 
   keycloak:
     realm: https://sso.digital.homeoffice.gov.uk/auth/realms/HOCS
-    domain: www.wcs.homeoffice.gov.uk
+    domain: www.wcs-management.homeoffice.gov.uk
 {{- else }}
   clusterPrefix: cs
 
   keycloak:
     realm: https://sso.digital.homeoffice.gov.uk/auth/realms/hocs-prod
-    domain: www.cs.homeoffice.gov.uk
+    domain: www.cs-management.homeoffice.gov.uk
 {{- end }}
 
   app:


### PR DESCRIPTION
the frontend values were used here instead of the management-ui ones. Restoring the value based on:
https://github.com/UKHomeOffice/hocs-management-ui/blob/eb65bf5e5983e57a1e90603410ad2e56d7c3042f/kube/deploy.sh#L23