### PR TITLE
Use OpenSearch in QA Environment for Casework

### DIFF
--- a/environments/qa/values/hocs-casework.yaml.gotmpl
+++ b/environments/qa/values/hocs-casework.yaml.gotmpl
@@ -12,6 +12,8 @@ hocs-generic-service:
         cpu: 50m
 
   app:
+    env:
+      searchService: https://hocs-search-opensearch.{{ .Release.Namespace }}.svc.cluster.local
     resources:
       limits:
         memory: 768Mi


### PR DESCRIPTION
Specify to use the OpenSearch service in QA environments for serving search results from through hocs-casework.